### PR TITLE
Fix typo in SaveToFile comments

### DIFF
--- a/Xsd2Code.Library/Extensions/CodeExtension.cs
+++ b/Xsd2Code.Library/Extensions/CodeExtension.cs
@@ -1125,7 +1125,7 @@ namespace Xsd2Code.Library.Extensions
             saveToFileMethod.Comments.AddRange(
                 CodeDomHelper.GetSummaryComment(string.Format("Serializes current {0} object into file", type.Name)));
 
-            saveToFileMethod.Comments.Add(CodeDomHelper.GetParamComment("fileName", "full path of outupt xml file"));
+            saveToFileMethod.Comments.Add(CodeDomHelper.GetParamComment("fileName", "full path of output xml file"));
             saveToFileMethod.Comments.Add(CodeDomHelper.GetParamComment("exception", "output Exception value if failed"));
             saveToFileMethod.Comments.Add(CodeDomHelper.GetReturnComment("true if can serialize and save into file; otherwise, false"));
 


### PR DESCRIPTION
Generated code contains a typo:
```
<param name="fileName">full path of outupt xml file</param>
```

It is repeated for each generated class and triggers spell check, gets quite annoying.

This PR fixes the typo.